### PR TITLE
chore: upgrade to rustls 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ name = "deno_native_certs_test"
 path = "test_bin.rs"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-rustls-native-certs = "0.6.2"
+rustls-native-certs = "0.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 once_cell = "1.17.1"
 dlopen2 = "0.6.1"
 dlopen2_derive = "0.4.0"
-rustls-pemfile = "1.0.2"
+rustls-pemfile = "2"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
-rustls-native-certs = "0.6.2"
+rustls-native-certs = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub fn load_native_certs() -> Result<Vec<Certificate>, Error> {
   Ok(
     rustls_native_certs::load_native_certs()?
       .into_iter()
-      .map(|c| Certificate(c.0))
+      .map(|c| Certificate(c.to_vec()))
       .collect::<Vec<_>>(),
   )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,14 @@ pub fn load_native_certs() -> Result<Vec<Certificate>, Error> {
     let f = File::open(&path)?;
     let mut f = BufReader::new(f);
 
-    match rustls_pemfile::certs(&mut f) {
-      Ok(contents) => Ok(contents.into_iter().map(Certificate).collect()),
+    let certs: Result<Vec<_>, _> = rustls_pemfile::certs(&mut f).collect();
+    match certs {
+      Ok(contents) => Ok(
+        contents
+          .into_iter()
+          .map(|c| Certificate(c.to_vec()))
+          .collect(),
+      ),
       Err(_) => Err(Error::new(
         ErrorKind::InvalidData,
         format!("Could not load PEM file {:?}", path),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -354,7 +354,7 @@ mod tests {
     let mut expected = rustls_native_certs::load_native_certs()
       .unwrap()
       .into_iter()
-      .map(|cert| cert.0)
+      .map(|cert| cert.to_vec())
       .collect::<Vec<_>>();
 
     actual.sort();


### PR DESCRIPTION
part of https://github.com/denoland/deno/pull/24056

using versions as specified in the rustls 0.22 release notes.
https://github.com/rustls/rustls/releases/tag/v%2F0.22.0
